### PR TITLE
Fix import for Metadata, getMatchesFromEmbeddings

### DIFF
--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -12,7 +12,7 @@ import { uuid } from 'uuidv4';
 import { summarizeLongDocument } from './summarizer';
 
 import { ConversationLog } from './conversationLog';
-import { Metadata, getMatchesFromEmbeddings } from './embeddings';
+import { Metadata, getMatchesFromEmbeddings } from './matches';
 import { templates } from './templates';
 
 


### PR DESCRIPTION
## Problem

Fix this "bug Module not found error when running 'npm run dev'" **https://github.com/pinecone-io/chatbot-demo/issues/8**

## Solution

Wrong file name was imported.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

npm run dev 
